### PR TITLE
배포를 위한 파일 설정

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node src/app.js",
     "dev": "nodemon --watch src/ src/app.js",
-    "postinstall": "husky install",
+    "postinstall": "node -e \"if (process.env.NODE_ENV !== 'production'){process.exit(1)} \" || husky install",
     "format": "prettier --cache --write .",
     "lint": "eslint --cache ."
   },


### PR DESCRIPTION
# Description
- **cloudtype**을 활용해 배포를 하려했지만 `scripts `오류로 인하여 배포가 되지 않음
- `package.json` 파일에서  `scripts`의 `postinstall` 부분을 설정하여 오류 해결
## 관련문서
- https://github.com/typicode/husky/issues/945
- #13 