### PR TITLE
약속 생성 기능

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,7 @@ import { sequelize } from './models/index.js';
 import passport from 'passport';
 import authRouter from './routes/auth.js';
 import userRouter from './routes/user.js';
+import planRouter from './routes/plan.js';
 import testRouter from './routes/testRoute.js';
 import passportConfig from './passport/index.js';
 import redis from 'redis';
@@ -100,6 +101,7 @@ app.get('/', (req, res) => {
 // Routes
 app.use('/auth', authRouter);
 app.use('/user', userRouter);
+app.use('/plan', planRouter);
 app.use('/', testRouter);
 
 app.use((req, res, next) => {

--- a/src/controllers/plan.js
+++ b/src/controllers/plan.js
@@ -1,0 +1,59 @@
+import Plan from '../models/Plan.js';
+import PlanDateRange from '../models/PlanDateRange.js';
+import PlanMember from '../models/PlanMember.js';
+import User from '../models/User.js';
+
+export const createPlan = async (req, res, next) => {
+  const {
+    plan_title,
+    plan_description,
+    connection_type,
+    start_time,
+    end_time,
+    location,
+    date_range,
+  } = req.body;
+  try {
+    const plan = await Plan.create({
+      user_id: req.user.id,
+      plan_title,
+      plan_description,
+      connection_type,
+      start_time,
+      end_time,
+    });
+    if (connection_type === 'online') {
+      plan.online_link = location;
+    } else {
+      plan.offline_location = location;
+    }
+    plan.save();
+
+    await PlanMember.create({ user_id: req.user.id, plan_id: plan.plan_id });
+
+    await Promise.all(
+      date_range.map((date) => PlanDateRange.create({ date, plan_id: plan.plan_id }))
+    );
+
+    const fullPlan = await Plan.findOne({
+      where: { plan_id: plan.plan_id },
+      include: [
+        {
+          model: PlanMember,
+          include: [
+            { model: User, attributes: ['id', 'nickname', 'profile_color', 'description'] },
+          ],
+        },
+        {
+          model: PlanDateRange,
+          attributes: ['plan_date_id', 'date'],
+        },
+      ],
+    });
+
+    res.status(201).json({ success: true, data: fullPlan, error: null });
+  } catch (error) {
+    console.error(error);
+    next(error);
+  }
+};

--- a/src/controllers/plan.js
+++ b/src/controllers/plan.js
@@ -43,6 +43,7 @@ export const createPlan = async (req, res, next) => {
           include: [
             { model: User, attributes: ['id', 'nickname', 'profile_color', 'description'] },
           ],
+          attributes: ['plan_member_id'],
         },
         {
           model: PlanDateRange,

--- a/src/models/Plan.js
+++ b/src/models/Plan.js
@@ -7,10 +7,16 @@ class Plan extends Sequelize.Model {
   static initiate(sequelize) {
     Plan.init(
       {
-        id: {
+        plan_id: {
           type: Sequelize.INTEGER,
           primaryKey: true,
           autoIncrement: true,
+          allowNull: false,
+        },
+        user_id: {
+          type: Sequelize.INTEGER,
+          primaryKey: true,
+          allowNull: false,
         },
         plan_title: {
           type: Sequelize.STRING(40),
@@ -72,9 +78,9 @@ class Plan extends Sequelize.Model {
   }
 
   static associate() {
-    Plan.belongsTo(User);
-    Plan.hasMany(PlanMember);
-    Plan.hasMany(PlanDateRange);
+    Plan.belongsTo(User, { targetKey: 'id', foreignKey: 'user_id' });
+    Plan.hasMany(PlanMember, { sourceKey: 'plan_id', foreignKey: 'plan_id' });
+    Plan.hasMany(PlanDateRange, { sourceKey: 'plan_id', foreignKey: 'plan_id' });
   }
 }
 

--- a/src/models/Plan.js
+++ b/src/models/Plan.js
@@ -68,7 +68,7 @@ class Plan extends Sequelize.Model {
         sequelize,
         timestamps: true,
         underscored: true,
-        modelName: 'Plan',
+        modelName: 'plan',
         tableName: 'plan',
         paranoid: false,
         charset: 'utf8',

--- a/src/models/Plan.js
+++ b/src/models/Plan.js
@@ -1,0 +1,81 @@
+import Sequelize from 'sequelize';
+import User from './User.js';
+import PlanMember from './PlanMember.js';
+import PlanDateRange from './PlanDateRange.js';
+
+class Plan extends Sequelize.Model {
+  static initiate(sequelize) {
+    Plan.init(
+      {
+        id: {
+          type: Sequelize.INTEGER,
+          primaryKey: true,
+          autoIncrement: true,
+        },
+        plan_title: {
+          type: Sequelize.STRING(40),
+          allowNull: false,
+        },
+        plan_description: {
+          type: Sequelize.STRING(100),
+          allowNull: true,
+        },
+        connection_type: {
+          type: Sequelize.ENUM('online', 'offline'),
+          allowNull: false,
+        },
+        offline_location: {
+          type: Sequelize.STRING(40),
+          allowNull: true,
+        },
+        online_link: {
+          type: Sequelize.STRING(255),
+          allowNull: true,
+        },
+        start_time: {
+          type: Sequelize.TIME,
+          allowNull: false,
+        },
+        end_time: {
+          type: Sequelize.TIME,
+          allowNull: false,
+        },
+        plan_status: {
+          type: Sequelize.ENUM('조정중', '확정', '종료'),
+          allowNull: false,
+          defaultValue: '조정중',
+        },
+        plan_confirm_date: {
+          type: Sequelize.DATEONLY(),
+          allowNull: true,
+        },
+        plan_confirm_time: {
+          type: Sequelize.TIME(),
+          allowNull: true,
+        },
+        plan_confirm_location: {
+          type: Sequelize.STRING(40),
+          allowNull: true,
+        },
+      },
+      {
+        sequelize,
+        timestamps: true,
+        underscored: true,
+        modelName: 'Plan',
+        tableName: 'plan',
+        paranoid: false,
+        charset: 'utf8',
+        collate: 'utf8_general_ci',
+      }
+    );
+  }
+
+  static associate() {
+    Plan.belongsTo(User);
+    Plan.hasMany(PlanMember);
+    Plan.hasMany(PlanDateRange);
+  }
+}
+
+export default Plan;

--- a/src/models/PlanDateRange.js
+++ b/src/models/PlanDateRange.js
@@ -5,13 +5,19 @@ class PlanDateRange extends Sequelize.Model {
   static initiate(sequelize) {
     PlanDateRange.init(
       {
-        id: {
+        plan_date_id: {
           type: Sequelize.INTEGER,
           primaryKey: true,
           autoIncrement: true,
+          allowNull: false,
         },
         date: {
           type: Sequelize.DATEONLY(),
+          allowNull: false,
+        },
+        plan_id: {
+          type: Sequelize.INTEGER,
+          primaryKey: true,
           allowNull: false,
         },
       },
@@ -29,7 +35,7 @@ class PlanDateRange extends Sequelize.Model {
   }
 
   static associate() {
-    PlanDateRange.belongsTo(Plan);
+    PlanDateRange.belongsTo(Plan, { targetKey: 'plan_id', foreignKey: 'plan_id' });
   }
 }
 

--- a/src/models/PlanDateRange.js
+++ b/src/models/PlanDateRange.js
@@ -1,0 +1,36 @@
+import Sequelize from 'sequelize';
+import Plan from './Plan.js';
+
+class PlanDateRange extends Sequelize.Model {
+  static initiate(sequelize) {
+    PlanDateRange.init(
+      {
+        id: {
+          type: Sequelize.INTEGER,
+          primaryKey: true,
+          autoIncrement: true,
+        },
+        date: {
+          type: Sequelize.DATEONLY(),
+          allowNull: false,
+        },
+      },
+      {
+        sequelize,
+        timestamps: true,
+        underscored: true,
+        modelName: 'PlanDateRange',
+        tableName: 'plan_date_range',
+        paranoid: false,
+        charset: 'utf8',
+        collate: 'utf8_general_ci',
+      }
+    );
+  }
+
+  static associate() {
+    PlanDateRange.belongsTo(Plan);
+  }
+}
+
+export default PlanDateRange;

--- a/src/models/PlanDateRange.js
+++ b/src/models/PlanDateRange.js
@@ -25,7 +25,7 @@ class PlanDateRange extends Sequelize.Model {
         sequelize,
         timestamps: true,
         underscored: true,
-        modelName: 'PlanDateRange',
+        modelName: 'plan_date_range',
         tableName: 'plan_date_range',
         paranoid: false,
         charset: 'utf8',

--- a/src/models/PlanMember.js
+++ b/src/models/PlanMember.js
@@ -27,7 +27,7 @@ class PlanMember extends Sequelize.Model {
         sequelize,
         timestamps: true,
         underscored: true,
-        modelName: 'PlanMember',
+        modelName: 'plan_member',
         tableName: 'plan_member',
         paranoid: false,
         charset: 'utf8',

--- a/src/models/PlanMember.js
+++ b/src/models/PlanMember.js
@@ -1,0 +1,34 @@
+import Sequelize from 'sequelize';
+import User from './User.js';
+import Plan from './Plan.js';
+
+class PlanMember extends Sequelize.Model {
+  static initiate(sequelize) {
+    PlanMember.init(
+      {
+        id: {
+          type: Sequelize.INTEGER,
+          primaryKey: true,
+          autoIncrement: true,
+        },
+      },
+      {
+        sequelize,
+        timestamps: true,
+        underscored: true,
+        modelName: 'PlanMember',
+        tableName: 'plan_member',
+        paranoid: false,
+        charset: 'utf8',
+        collate: 'utf8_general_ci',
+      }
+    );
+  }
+
+  static associate() {
+    PlanMember.belongsTo(User);
+    PlanMember.belongsTo(Plan);
+  }
+}
+
+export default PlanMember;

--- a/src/models/PlanMember.js
+++ b/src/models/PlanMember.js
@@ -6,10 +6,21 @@ class PlanMember extends Sequelize.Model {
   static initiate(sequelize) {
     PlanMember.init(
       {
-        id: {
+        plan_member_id: {
           type: Sequelize.INTEGER,
           primaryKey: true,
           autoIncrement: true,
+          allowNull: false,
+        },
+        user_id: {
+          type: Sequelize.INTEGER,
+          primaryKey: true,
+          allowNull: false,
+        },
+        plan_id: {
+          type: Sequelize.INTEGER,
+          primaryKey: true,
+          allowNull: false,
         },
       },
       {
@@ -26,8 +37,8 @@ class PlanMember extends Sequelize.Model {
   }
 
   static associate() {
-    PlanMember.belongsTo(User);
-    PlanMember.belongsTo(Plan);
+    PlanMember.belongsTo(User, { targetKey: 'id', foreignKey: 'user_id' });
+    PlanMember.belongsTo(Plan, { targetKey: 'plan_id', foreignKey: 'plan_id' });
   }
 }
 

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -10,6 +10,7 @@ class User extends Sequelize.Model {
           type: Sequelize.INTEGER,
           primaryKey: true,
           autoIncrement: true,
+          allowNull: false,
         },
         email: {
           type: Sequelize.STRING(40),
@@ -69,8 +70,8 @@ class User extends Sequelize.Model {
   }
 
   static associate() {
-    User.hasMany(Plan);
-    User.hasMany(PlanMember);
+    User.hasMany(Plan, { sourceKey: 'id', foreignKey: 'user_id' });
+    User.hasMany(PlanMember, { sourceKey: 'id', foreignKey: 'user_id' });
   }
 }
 

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -1,4 +1,6 @@
 import Sequelize from 'sequelize';
+import Plan from './Plan.js';
+import PlanMember from './PlanMember.js';
 
 class User extends Sequelize.Model {
   static initiate(sequelize) {
@@ -56,7 +58,7 @@ class User extends Sequelize.Model {
       {
         sequelize,
         timestamps: true,
-        underscored: false,
+        underscored: true,
         modelName: 'User',
         tableName: 'user',
         paranoid: false,
@@ -66,7 +68,10 @@ class User extends Sequelize.Model {
     );
   }
 
-  static associate(db) {}
+  static associate() {
+    User.hasMany(Plan);
+    User.hasMany(PlanMember);
+  }
 }
 
 export default User;

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -60,7 +60,7 @@ class User extends Sequelize.Model {
         sequelize,
         timestamps: true,
         underscored: true,
-        modelName: 'User',
+        modelName: 'user',
         tableName: 'user',
         paranoid: false,
         charset: 'utf8',

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,6 +1,9 @@
 import Sequelize from 'sequelize';
 import DEVELOPMENT from '../config/config.js';
 import User from './User.js';
+import Plan from './Plan.js';
+import PlanMember from './PlanMember.js';
+import PlanDateRange from './PlanDateRange.js';
 
 const db = {};
 
@@ -21,7 +24,13 @@ export const sequelize = new Sequelize(
 db.sequelize = sequelize;
 
 User.initiate(sequelize);
+Plan.initiate(sequelize);
+PlanMember.initiate(sequelize);
+PlanDateRange.initiate(sequelize);
 
-User.associate(db);
+User.associate();
+Plan.associate();
+PlanMember.associate();
+PlanDateRange.associate();
 
 export default db;

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -18,6 +18,14 @@ export const sequelize = new Sequelize(
     dialectOptions: {
       timezone: '+09:00', // DB에서 가져올 때 시간 설정
     },
+    define: {
+      timestamps: true,
+      undersocred: true,
+      underscoredAll: true,
+      createdAt: 'created_at',
+      updatedAt: 'updated_at',
+      deletedAt: 'deleted_at',
+    },
   }
 );
 

--- a/src/routes/plan.js
+++ b/src/routes/plan.js
@@ -1,0 +1,9 @@
+import express from 'express';
+import { createPlan } from '../controllers/plan.js';
+import { isSignedIn } from '../middlewares/index.js';
+
+const router = express.Router();
+
+router.post('/', isSignedIn, createPlan);
+
+export default router;


### PR DESCRIPTION
# Description
- 약속 생성 기능
- **sequelize 설정에 define 추가** 
모델 설정에서 `underscore:true`로 설정해도 테이블 컬럼은 `created_at`, `updated_at`으로 생성되지만 테이블 참조하여 응답값을 보낼 때는 `createdAt`, `updatedAt`과 같은 `camelCase`로 생성되어 sequelize 설정을 수정했습니다.
- Plan, PlanMember, PlanDateRange 모델 추가

# Issue number
- #29 